### PR TITLE
nais/docker-build-push pusher images uten navikt-prefix

### DIFF
--- a/.github/actions/maven/build-push-docker-image/action.yml
+++ b/.github/actions/maven/build-push-docker-image/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Adds a suffix to the generated docker image name"
     required: false
     default: ""
+  without_navikt_prefix:
+    description: "Do not include navikt prefix in docker image name"
+    required: false
+    default: "false"
 outputs:
   image-artifact-name:
     description: 'artifact id of uploaded image'
@@ -65,11 +69,20 @@ runs:
           echo "::error ::Docker context not found: ${{ inputs.docker_context }}."
           exit 1
         fi
+    - name: Generate docker image name
+      id: docker_image_name
+      run: |
+        if [ "${{ inputs.without_navikt_prefix }}" == "true" ]; then
+            repo_name_without_owner=$(echo ${{ github.repository }} | cut -d'/' -f2)
+            echo "REPO_NAME=${{ steps.login.outputs.registry }}/${repo_name_without_owner}${{ inputs.image_suffix }}" >> $GITHUB_OUTPUT
+        else
+            echo "REPO_NAME=${{ steps.login.outputs.registry }}/${{ github.repository }}${{ inputs.image_suffix }}" >> $GITHUB_OUTPUT
+        fi
     - name: Docker meta
       uses: docker/metadata-action@9dc751fe249ad99385a2583ee0d084c400eee04e # ratchet:docker/metadata-action@v4
       id: meta
       with:
-        images: ${{ steps.login.outputs.registry }}/${{ github.repository }}${{ inputs.image_suffix }}
+        images: ${{ steps.docker_image_name.outputs.REPO_NAME}}
         tags: |
           type=raw,value=${{ inputs.build-version }}
           # set latest tag for default branch (master)


### PR DESCRIPTION
nais/docker-build-push pusher images uten navikt-prefix, mens vår build-push-docker-image har det med. 

Når jeg bruker vår build-push-docker-image for å bygge image lokalt til bruk i verdikjede, så får jeg en mismatch mellom metadata på imaget jeg loader og det som er i update-versions.sh