### PR TITLE
Output image tag

### DIFF
--- a/.github/actions/maven/build-push-docker-image/action.yml
+++ b/.github/actions/maven/build-push-docker-image/action.yml
@@ -141,6 +141,7 @@ runs:
     - name: Set outputs
       shell: bash
       id: set-outputs
+      if: inputs.push-image == 'true'
       run: |
         echo "NEW_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_OUTPUT
         echo "IMAGE=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT

--- a/.github/actions/maven/build-push-docker-image/action.yml
+++ b/.github/actions/maven/build-push-docker-image/action.yml
@@ -59,6 +59,12 @@ outputs:
   image-artifact-name:
     description: 'artifact id of uploaded image'
     value: ${{ steps.image-artifact-name.outputs.image_artifact_name }}
+  image:
+    description: "Image name"
+    value: ${{ steps.set-outputs.outputs.IMAGE }}
+  tag:
+    description: "Release tag"
+    value: ${{ steps.set-outputs.outputs.NEW_VERSION }}
 runs:
   using: "composite"
   steps:
@@ -132,6 +138,12 @@ runs:
       uses: nais/attest-sign@5e9450cc8a617286ca2d22859011e078ad1ef583 # ratchet:nais/attest-sign@v1
       with:
         image_ref: "${{ steps.docker_image_name.outputs.REPO_NAME}}@${{ steps.build_push.outputs.digest }}"
+    - name: Set outputs
+      shell: bash
+      id: set-outputs
+      run: |
+        echo "NEW_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_OUTPUT
+        echo "IMAGE=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
     - name: Upload image
       if: inputs.upload-image == 'true'
       uses: actions/upload-artifact@v4

--- a/.github/actions/maven/build-push-docker-image/action.yml
+++ b/.github/actions/maven/build-push-docker-image/action.yml
@@ -106,8 +106,8 @@ runs:
         images: ${{ steps.docker_image_name.outputs.REPO_NAME}}
         tags: |
           # Create build-version tag if it is not set:
-          type=sha,prefix={{date 'YYYY.MM.DD-HH.mm'}}-,priority=50,enable=${{ inputs.build-version == '' }}
-          type=raw,value=${{ inputs.build-version }}
+          type=sha,prefix={{date 'YYYY.MM.DD-HH.mm'}}-,priority=250,enable=${{ inputs.build-version == '' }}
+          type=raw,value=${{ inputs.build-version }},priority=255
           type=raw,value=${{ inputs.additional-tag }},enable=${{ inputs.additional-tag != null }}
           # set latest tag for default branch (master)
           type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
**Bakgrunn**
Behov for å få ut image tag som skal brukast til deploy action frå build-push-docker-image.

**Løysing**
Fikser prioritet på tags generert i docker/metadata-action slik at versjonsreferanse tag alltid blir høgare prioritert enn "latest".

Setter outputs "image" og "tag" på samme måte som nais/docker-build-push action gjere, slik at denne info enkelt kan brukast i deploy kall i seinare steg.