### PR TITLE
Deploy workflow override image name

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -47,7 +47,6 @@ on:
         required: false
         type: string
         description: 'Overstyrer hele image navnet. Nødvendig når man bruker nais/docker-build-push@v0 for å pushe image, da denne ikke inkluderer navikt/ i image navnet.'
-        ## eks 
         ## med navikt/sif-gha-workflows/.github/actions/maven/build-push-docker-image@main: 
         ### europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/k9-los-web:2025.01.02-07.21-592847c
         ## med nais/docker-build-push@v0

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -29,11 +29,6 @@ on:
         required: false
         type: string
         description: 'The naiserator.yaml file name in .deploy/ to use'
-      deploy_context:
-        required: false
-        type: string
-        description: 'The deploy context /'
-        default: ''
       image_suffix:
         required: false
         type: string

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -42,15 +42,11 @@ on:
       branch:
         required: false
         type: string
-        description: 'Alternativ branch å deploye fra'
+        description: 'Alternative branch to deploy from'
       override_image_name:
         required: false
         type: string
-        description: 'Overstyrer hele image navnet. Nødvendig når man bruker nais/docker-build-push@v0 for å pushe image, da denne ikke inkluderer navikt/ i image navnet.'
-        ## med navikt/sif-gha-workflows/.github/actions/maven/build-push-docker-image@main: 
-        ### europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/k9-los-web:2025.01.02-07.21-592847c
-        ## med nais/docker-build-push@v0
-        ## europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/k9-los-web:2025.01.02-07.21-592847c
+        description: 'Complete image name to deploy. When set, image and image_suffix inputs are ignored. For use when image to upload don't have navikt/ prefix'
         default: ''
 env:
   IMAGE: ${{ inputs.image }} # Brukes i naiserator.yaml

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           PRINT_PAYLOAD: true
           CLUSTER: ${{ inputs.cluster }}
-          IMAGE: ${{ steps.login.outputs.registry }}/${{ github.repository }}${{ inputs.image_suffix }}:${{ inputs.image }}
+          IMAGE: ${{ inputs.override_image_name != '' && inputs.override_image_name || format('{0}/{1}{2}:{3}', steps.login.outputs.registry, github.repository, inputs.image_suffix, inputs.image) }}
           RESOURCE: ${{ inputs.naiserator_file }}
           VARS: ${{ inputs.input_vars_file }}
       - name: Finn commit sha fra image navn

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -41,7 +41,7 @@ on:
       override_image_name:
         required: false
         type: string
-        description: 'Complete image name to deploy. When set, image and image_suffix inputs are ignored. For use when image to upload don't have navikt/ prefix'
+        description: 'Complete image name to deploy. When set, image and image_suffix inputs are ignored. For use when image to upload does not have /navikt prefix'
         default: ''
 env:
   IMAGE: ${{ inputs.image }} # Brukes i naiserator.yaml

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -43,7 +43,16 @@ on:
         required: false
         type: string
         description: 'Alternativ branch å deploye fra'
-
+      override_image_name:
+        required: false
+        type: string
+        description: 'Overstyrer hele image navnet. Nødvendig når man bruker nais/docker-build-push@v0 for å pushe image, da denne ikke inkluderer navikt/ i image navnet.'
+        ## eks 
+        ## med navikt/sif-gha-workflows/.github/actions/maven/build-push-docker-image@main: 
+        ### europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/navikt/k9-los-web:2025.01.02-07.21-592847c
+        ## med nais/docker-build-push@v0
+        ## europe-north1-docker.pkg.dev/nais-management-233d/k9saksbehandling/k9-los-web:2025.01.02-07.21-592847c
+        default: ''
 env:
   IMAGE: ${{ inputs.image }} # Brukes i naiserator.yaml
   PROD_TAG: latest_${{ inputs.cluster }}_${{ inputs.namespace }}${{ inputs.image_suffix }}


### PR DESCRIPTION
Tenkte ta i bruk workflowen i k9-los-web. Men blir hindret av at workflowen forventer at man har **navikt/** i imagenavnet.

Bruker man navikt/sif-gha-workflows/.github/actions/maven/build-push-docker-image@main får man imagenavn som inkluderer navikt/
Bruker man nais/docker-build-push@v0 får man imagenavn uten navikt/. 