### PR TITLE
generate-openapi action: Valgfritt om generert fil skal committes.

### DIFF
--- a/.github/actions/maven/generate-openapi/action.yaml
+++ b/.github/actions/maven/generate-openapi/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: What filename to use for generated openapi.json file.
     required: true
     default: openapi.json
+  dontCommit:
+    description: If true, do not commit the generated openapi.json file.
+    required: false
+    default: "false"
 outputs:
   openapiVersion:
     description: "generated openapi spec version"
@@ -46,7 +50,7 @@ runs:
           core.setFailed('fant ikkje korrekt openapi version frå ${{ inputs.openapiFileName }}')
     # Commit and push any changes to openapi.json
     - name: Commit api endringer
-      if: ${{ success() }}
+      if: ${{ success() && inputs.dontCommit != 'true' }}
       id: change-commit
       shell: bash
       env:

--- a/.github/actions/maven/generate-openapi/action.yaml
+++ b/.github/actions/maven/generate-openapi/action.yaml
@@ -33,7 +33,7 @@ runs:
         skip-tests: true
     - name: Openapi generate
       shell: bash
-      run: mvn exec:java --projects web
+      run: mvn -s settings.xml exec:java --projects web
     - name: Openapi version
       id: openapi-version
       shell: bash


### PR DESCRIPTION
## Bakgrunn

Behov for å kunne generer openapi.json fil i repo uten å utføre commit.

## Løsning

Legger til valgfri parameter til action. Viss satt blir generert fil ikkje forsøkt committa.