### PR TITLE
Java25

### DIFF
--- a/.github/actions/maven/generate-openapi/action.yaml
+++ b/.github/actions/maven/generate-openapi/action.yaml
@@ -15,10 +15,6 @@ inputs:
     description: If true, do not commit the generated openapi.json file.
     required: false
     default: "false"
-  java-version:
-    required: false
-    description: Java SDK versjon som skal brukes.
-    default: '21'
 outputs:
   openapiVersion:
     description: "generated openapi spec version"
@@ -30,15 +26,11 @@ runs:
     - name: Setup java and maven
       uses: navikt/sif-gha-workflows/.github/actions/maven/setup-java-and-maven@main
       with:
-        java-version: ${{ inputs.java-version }}
         github-token: ${{ inputs.readerToken }}
     - name: Maven install
       uses: navikt/sif-gha-workflows/.github/actions/maven/test-and-build@main
       with:
         skip-tests: true
-    - name: Echo versions
-      shell: bash
-      run: mvn -version
     - name: Openapi generate
       shell: bash
       run: mvn -s settings.xml exec:java --projects web

--- a/.github/actions/maven/generate-openapi/action.yaml
+++ b/.github/actions/maven/generate-openapi/action.yaml
@@ -27,6 +27,8 @@ runs:
       uses: navikt/sif-gha-workflows/.github/actions/maven/setup-java-and-maven@main
       with:
         github-token: ${{ inputs.readerToken }}
+        # Ved ny jdk versjon kan denne økes uten å vente på noe annet. (Kompileringsresultat fra denne action blir ikke brukt noe annet sted.)
+        java-version: '25'
     - name: Maven install
       uses: navikt/sif-gha-workflows/.github/actions/maven/test-and-build@main
       with:


### PR DESCRIPTION
## Bakgrunn

Avhengigheter begynner å bygges med java versjon 25.

## Løsning

Øker java versjon brukt i openapi-generate til 25.

Treng ikkje ha denne parameterisert, kan køyre på java 25 for denne jobb over alt sidan den ikkje bygger eit java resultat som brukast av andre.