### PR TITLE
printing av repo digest feiler hvis den ikke finnes, f.eks. hvis det …

### DIFF
--- a/.github/actions/maven/verdikjede-test-v2/action.yml
+++ b/.github/actions/maven/verdikjede-test-v2/action.yml
@@ -126,7 +126,9 @@ runs:
         echo "Printer repo digest for alle imager"
         echo "RepoDigest  image.version"
         set -v
-        docker ps --format "{{.Image}}" | xargs -I {} docker inspect --format '{{join .RepoDigests ", "}} {{index .Config.Labels "org.opencontainers.image.version"}}' {}
+        docker ps --format "{{.Image}}" | while read -r img; do
+          docker inspect --format '{{join .RepoDigests ", "}} {{index .Config.Labels "org.opencontainers.image.version"}}' "$img" 2>/dev/null || echo "SKIPPED: $img"
+        done
         set +v
 
     - name: Venter på stacken og sjekker status


### PR DESCRIPTION
…hardkodes mot en eldre versjon av VTP. Ignorerer og printer heller SKIPPED