### PR TITLE
Støtte for å publisere selvstendig kontrakt

### DIFF
--- a/.github/actions/maven/release/action.yml
+++ b/.github/actions/maven/release/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: |
         mvn -B -s settings-build.xml versions:set -DnewVersion=${{ inputs.release-version }} ${{ inputs.release-file }}
-        mvn -B -s settings-build.xml package ${{ inputs.mvn-projects }} -DtrimStackTrace=false -Dfile.encoding=UTF-8
+        mvn -B -s settings-build.xml package ${{ inputs.mvn-projects }} ${{ inputs.release-file }} -DtrimStackTrace=false -Dfile.encoding=UTF-8
 
 
     - name: Create maven .m2 settings for release


### PR DESCRIPTION
### Behov / Bakgrunn
K9-inntektsmeldinger har behov for å publisere kontrakter som k9-inntektsmelding-api og k9-sak kan ta i bruk.

Det er ganske omfattende (krever en stor omstrukturering av koden) å skrive om k9-inntektsmelding til multi-modul. Vi ønsker derfor å teste om det fungerer greit å publisere en selvstendig kontrakt slik som foreldrepenger gjør det.

### Løsning
I følge copilot må vi legge til en et argument for at det skal bygges riktig. 


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
